### PR TITLE
docs: Include defaults in reference.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ committed HEAD~..HEAD^2 --no-merge-commit
 ```
 See [`imperative` for an Azure Pipeline
 example](https://github.com/crate-ci/imperative/blob/master/azure-pipelines.yml)
-or look at `committed`s own [`azure-pipelines.yml`](azure-pipelnes.yml),
+or look at `committed`s own [`azure-pipelines.yml`](azure-pipelines.yml),
 [`.travis.yml`](.travis.yml), or [`appveyor.yml`](appveyor.yml).
 
 ## [Reference](docs/reference.md)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -47,19 +47,19 @@ Configuration is read from the following (in precedence order)
 
 ### Config Fields
 
-| Field                  | Argument          | Format | Description |
-|------------------------|-------------------|--------|-------------|
-| ignore_author_re       | \-                | regx   | Authors to ignore the commits for. Generally used with bots out of your control. |
-| subject_length         | \-                | number | Number of columns the subject can occupy |
-| line_length            | \-                | number | Number of columns any line with a break can occupy, including subject |
-| hard_line_length       | \-                | number | Max number of columns any line can occupy. |
-| subject_capitalized    | \-                | bool   | Whether the subject is required to be capitalized |
-| subject_not_punctuated | \-                | bool   | Prevent the subject from ending in punctuation |
-| imperative_subject     | \-                | bool   | Require the subject to start with an imperative verb |
-| no_fixup               | \-                | bool   | Disallow fixup commits |
-| no_wip                 | \-                | bool   | Disallow WIP commits |
-| style                  | \-                | none, [conventional] | Commit style convention |
-| allowed_types          | \-                | list of strings | _(Conventional)_ Accepted commit types |
-| merge_commit           | --no-merge-commit | \-     | Disallow merge commits. Argument is recommended over config file since there are times when merge-commits are wanted. |
+| Field                  | Argument          | Format               | Default                                             | Description                                                                                                           |
+|------------------------|-------------------|----------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| ignore_author_re       | \-                | regx                 | (none)                                              | Authors to ignore the commits for. Generally used with bots out of your control.                                      |
+| subject_length         | \-                | number               | 50                                                  | Number of columns the subject can occupy                                                                              |
+| line_length            | \-                | number               | 72                                                  | Number of columns any line with a break can occupy, including subject                                                 |
+| hard_line_length       | \-                | number               | 0 (none)                                            | Max number of columns any line can occupy.                                                                            |
+| subject_capitalized    | \-                | bool                 | true                                                | Whether the subject is required to be capitalized                                                                     |
+| subject_not_punctuated | \-                | bool                 | true                                                | Prevent the subject from ending in punctuation                                                                        |
+| imperative_subject     | \-                | bool                 | true                                                | Require the subject to start with an imperative verb                                                                  |
+| no_fixup               | \-                | bool                 | true                                                | Disallow fixup commits                                                                                                |
+| no_wip                 | \-                | bool                 | true                                                | Disallow WIP commits                                                                                                  |
+| style                  | \-                | none, [conventional] | none                                                | Commit style convention                                                                                               |
+| allowed_types          | \-                | list of strings      | fix, feat, chore, docs, style, refactor, perf, test | _(Conventional)_ Accepted commit types                                                                                |
+| merge_commit           | --no-merge-commit | \-                   | true                                                | Disallow merge commits. Argument is recommended over config file since there are times when merge-commits are wanted. |
 
 [conventional]: https://www.conventionalcommits.org/


### PR DESCRIPTION
As proposed in #143, this commit adds the defaults from `config.rs` to `reference.md`. The goal is to help clarify what exactly `committed` will enforce by default.

If you think a different approach would work better, I am happy to try something else! Also, some vim plugin decided to format the table this way, let me know if you'd like it done another way.

One thing I noted while looking at the reference is that `merge_commit` is a little confusing, since the config option is not prefixed with `no_`, unlike `no_wip` and `no_fixup`. The command line format is the opposite: `--no-merge-commit`, which is more clear. This results in `merge_commit: true` meaning "no merge commits" if I understand correctly.

Also fixes a typo in README.md linking to `azure-pipelines.yml`