### PR TITLE
feat(config): Support dumping a full config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,63 @@ pub struct Config {
 }
 
 impl Config {
+    pub fn from_defaults() -> Self {
+        let empty = Self::default();
+        Self {
+            ignore_author_re: empty.ignore_author_re().map(|s| s.to_owned()),
+            subject_length: Some(empty.subject_length()),
+            subject_capitalized: Some(empty.subject_capitalized()),
+            subject_not_punctuated: Some(empty.subject_not_punctuated()),
+            imperative_subject: Some(empty.imperative_subject()),
+            no_fixup: Some(empty.no_fixup()),
+            no_wip: Some(empty.no_wip()),
+            hard_line_length: Some(empty.hard_line_length()),
+            line_length: Some(empty.line_length()),
+            style: Some(empty.style()),
+            allowed_types: Some(empty.allowed_types().map(|s| s.to_owned()).collect()),
+            merge_commit: Some(empty.merge_commit()),
+        }
+    }
+
+    pub fn update(&mut self, source: Self) {
+        if let Some(source) = source.ignore_author_re {
+            self.ignore_author_re = Some(source);
+        }
+        if let Some(source) = source.subject_length {
+            self.subject_length = Some(source);
+        }
+        if let Some(source) = source.subject_capitalized {
+            self.subject_capitalized = Some(source);
+        }
+        if let Some(source) = source.subject_not_punctuated {
+            self.subject_not_punctuated = Some(source);
+        }
+        if let Some(source) = source.imperative_subject {
+            self.imperative_subject = Some(source);
+        }
+        if let Some(source) = source.no_fixup {
+            self.no_fixup = Some(source);
+        }
+        if let Some(source) = source.no_wip {
+            self.no_wip = Some(source);
+        }
+        if let Some(source) = source.hard_line_length {
+            self.hard_line_length = Some(source);
+        }
+        if let Some(source) = source.line_length {
+            self.line_length = Some(source);
+        }
+        if let Some(source) = source.style {
+            self.style = Some(source);
+        }
+        if let Some(source) = source.allowed_types {
+            self.allowed_types = Some(source);
+        }
+        if let Some(source) = source.merge_commit {
+            self.merge_commit = Some(source);
+        }
+    }
+
     pub fn update_merge_commit(&mut self, merge_commit: Option<bool>) {
         if merge_commit.is_some() {
             self.merge_commit = merge_commit;


### PR DESCRIPTION
This makes the config more self-documenting and can then be used in CI
pipelines to tell the user the standard.

Related to #143