### PR TITLE
fix(check): Expand WIP prefixes

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -251,8 +251,10 @@ fn check_allowed_types(
     Ok(true)
 }
 
-static WIP_RE: once_cell::sync::Lazy<regex::Regex> =
-    once_cell::sync::Lazy::new(|| regex::Regex::new("^(wip|WIP)\\b").unwrap());
+// For Gitlab's rules, see https://docs.gitlab.com/ee/user/project/merge_requests/work_in_progress_merge_requests.html
+static WIP_RE: once_cell::sync::Lazy<regex::Regex> = once_cell::sync::Lazy::new(|| {
+    regex::Regex::new(r#"^(wip\b|WIP\b|\[WIP\]|Draft\b|\[Draft\]|\(Draft\))"#).unwrap()
+});
 
 pub fn check_wip(
     source: report::Source,


### PR DESCRIPTION
Gitlab has a different, more codified WIP system.  Let's support it