### PR TITLE
fix: Switch punctuation check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,7 +141,7 @@ stages:
           channel: ${{ variables.minrust }}
         next:
           channel: stable
-    continueOnError: $[eq(variables.rust, 'stable')]
+    continueOnError: $[eq(variables.channel, 'stable')]
     pool:
       vmImage: ${{ variables.linux_vm }}
     steps:

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -197,7 +197,7 @@ pub fn check_subject_not_punctuated(
         .chars()
         .last()
         .ok_or_else(|| anyhow::anyhow!("Subject cannot be empty"))?;
-    if last.is_ascii_punctuation() && last != '`' {
+    if " .!?".contains(last) {
         report(report::Message::error(
             source,
             report::NoPunctuation { punctuation: last },


### PR DESCRIPTION
Before, we only allowed letters.  This was restictive because there are
some things that make sense to end with, like quotes.  So switching to
listing what is not allowed.