### PR TITLE
fix: Report empty commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Bug Fixes
+
+- Show empty-commit errors as messages
+
 ## [0.1.26] - 2021-09-06
 
 ## [0.1.25] - 2021-07-02

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -95,7 +95,7 @@ fn check_has_message(
     report: report::Report,
 ) -> Result<bool, anyhow::Error> {
     if message.trim().is_empty() {
-        report(report::Message::error(source, report::EmpyCommit {}));
+        report(report::Message::error(source, report::EmptyCommit {}));
         Ok(true)
     } else {
         Ok(false)

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -95,7 +95,7 @@ fn check_has_message(
     report: report::Report,
 ) -> Result<bool, anyhow::Error> {
     if message.trim().is_empty() {
-        report(report::Message::error(source, report::Content::EmpyCommit));
+        report(report::Message::error(source, report::EmpyCommit {}));
         Ok(true)
     } else {
         Ok(false)

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -8,13 +8,18 @@ pub fn check_message(
     report: report::Report,
 ) -> Result<bool, anyhow::Error> {
     let mut failed = false;
+
+    failed |= check_has_message(source, message, report)?;
+    if failed {
+        return Ok(failed);
+    }
+
     if config.no_wip() {
         failed |= check_wip(source, message, report)?;
     }
     if config.no_fixup() {
         failed |= check_fixup(source, message, report)?;
     }
-
     // Bail out due to above checks
     if failed {
         return Ok(failed);
@@ -82,6 +87,19 @@ pub fn check_message(
     }
 
     Ok(failed)
+}
+
+fn check_has_message(
+    source: report::Source,
+    message: &str,
+    report: report::Report,
+) -> Result<bool, anyhow::Error> {
+    if message.trim().is_empty() {
+        report(report::Message::error(source, report::Content::EmpyCommit));
+        Ok(true)
+    } else {
+        Ok(false)
+    }
 }
 
 pub fn check_subject_length(

--- a/src/report.rs
+++ b/src/report.rs
@@ -49,6 +49,7 @@ pub enum Severity {
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
 pub enum Content<'s> {
+    EmpyCommit,
     SubjectTooLong(SubjectTooLong),
     LineTooLong(LineTooLong),
     CapitalizeSubject(CapitalizeSubject<'s>),

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,5 +1,6 @@
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub struct Message<'s> {
     pub source: Source<'s>,
     pub severity: Severity,
@@ -23,6 +24,7 @@ impl<'s> Message<'s> {
 #[derive(Copy, Clone, Debug, serde::Serialize, derive_more::From, derive_more::Display)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum Source<'s> {
     #[serde(serialize_with = "serialize_oid")]
     Oid(git2::Oid),
@@ -40,6 +42,7 @@ where
 
 #[derive(Copy, Clone, Debug, serde::Serialize, derive_more::Display)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum Severity {
     #[display(fmt = "error")]
     Error,
@@ -48,6 +51,7 @@ pub enum Severity {
 #[derive(Debug, serde::Serialize, derive_more::From, derive_more::Display)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Content<'s> {
     EmpyCommit,
     SubjectTooLong(SubjectTooLong),

--- a/src/report.rs
+++ b/src/report.rs
@@ -53,7 +53,7 @@ pub enum Severity {
 #[serde(tag = "type")]
 #[non_exhaustive]
 pub enum Content<'s> {
-    EmpyCommit,
+    EmpyCommit(EmpyCommit),
     SubjectTooLong(SubjectTooLong),
     LineTooLong(LineTooLong),
     CapitalizeSubject(CapitalizeSubject<'s>),
@@ -166,6 +166,12 @@ pub struct DisallowedCommitType {
 #[derive(derive_more::Display)]
 #[display(fmt = "Merge commits are disallowed")]
 pub struct MergeCommitDisallowed {}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(derive_more::Display)]
+#[display(fmt = "Empty commits are disallowed")]
+pub struct EmpyCommit {}
 
 pub type Report = fn(msg: Message);
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -53,7 +53,7 @@ pub enum Severity {
 #[serde(tag = "type")]
 #[non_exhaustive]
 pub enum Content<'s> {
-    EmpyCommit(EmpyCommit),
+    EmptyCommit(EmptyCommit),
     SubjectTooLong(SubjectTooLong),
     LineTooLong(LineTooLong),
     CapitalizeSubject(CapitalizeSubject<'s>),
@@ -171,7 +171,7 @@ pub struct MergeCommitDisallowed {}
 #[serde(rename_all = "snake_case")]
 #[derive(derive_more::Display)]
 #[display(fmt = "Empty commits are disallowed")]
-pub struct EmpyCommit {}
+pub struct EmptyCommit {}
 
 pub type Report = fn(msg: Message);
 


### PR DESCRIPTION
This switches it from an error to a message, making reporting nicer for
people who integrate this.

Fixes #194