### PR TITLE
fix: Show empty-commit messages for drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Bug Fixes
+
+- Show empty-commit errors as messages for draft commits
+
 ## [0.2.0] - 2021-09-07
 
 #### Bug Fixes


### PR DESCRIPTION
This will help with editor integration

Fixes #196