### PR TITLE
docs: Clarify default config file location

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -43,7 +43,7 @@ Configuration is read from the following (in precedence order)
 - Command line arguments
 - Either
   - File specified via `--config PATH`
-  - `$GIT/committed.toml`
+  - `<git repo directory>/committed.toml`
 
 ### Config Fields
 


### PR DESCRIPTION
`$GIT` looks like an environment variable, but is not.