### PR TITLE
Autosquash Improvements

### DIFF
--- a/crates/committed/src/checks.rs
+++ b/crates/committed/src/checks.rs
@@ -1,6 +1,8 @@
 use crate::report;
 use committed::Style;
 
+const AUTOSQUASH_PREFIXES: [&str; 3] = ["fixup! ", "squash! ", "amend! "];
+
 pub(crate) fn check_message(
     source: report::Source<'_>,
     message: &str,
@@ -17,8 +19,8 @@ pub(crate) fn check_message(
     if config.no_wip() {
         failed |= check_wip(source, message, report)?;
     }
-    if config.no_fixup() {
-        failed |= check_fixup(source, message, report)?;
+    if config.no_autosquash() {
+        failed |= check_autosquash(source, message, report)?;
     }
     // Bail out due to above checks
     if failed {
@@ -313,13 +315,13 @@ pub(crate) fn check_wip(
     }
 }
 
-pub(crate) fn check_fixup(
+pub(crate) fn check_autosquash(
     source: report::Source<'_>,
     message: &str,
     report: report::Report,
 ) -> Result<bool, anyhow::Error> {
-    if message.starts_with("fixup! ") {
-        report(report::Message::error(source, report::Fixup {}));
+    if AUTOSQUASH_PREFIXES.iter().any(|prefix| message.starts_with(prefix)) {
+        report(report::Message::error(source, report::Autosquash {}));
         Ok(true)
     } else {
         Ok(false)

--- a/crates/committed/src/config.rs
+++ b/crates/committed/src/config.rs
@@ -22,7 +22,8 @@ pub(crate) struct Config {
     pub(crate) subject_capitalized: Option<bool>,
     pub(crate) subject_not_punctuated: Option<bool>,
     pub(crate) imperative_subject: Option<bool>,
-    pub(crate) no_fixup: Option<bool>,
+    #[serde(alias = "no_fixup")]
+    pub(crate) no_autosquash: Option<bool>,
     pub(crate) no_wip: Option<bool>,
     pub(crate) hard_line_length: Option<usize>,
     pub(crate) line_length: Option<usize>,
@@ -40,7 +41,7 @@ impl Config {
             subject_capitalized: Some(empty.subject_capitalized()),
             subject_not_punctuated: Some(empty.subject_not_punctuated()),
             imperative_subject: Some(empty.imperative_subject()),
-            no_fixup: Some(empty.no_fixup()),
+            no_autosquash: Some(empty.no_autosquash()),
             no_wip: Some(empty.no_wip()),
             hard_line_length: Some(empty.hard_line_length()),
             line_length: Some(empty.line_length()),
@@ -66,8 +67,8 @@ impl Config {
         if let Some(source) = source.imperative_subject {
             self.imperative_subject = Some(source);
         }
-        if let Some(source) = source.no_fixup {
-            self.no_fixup = Some(source);
+        if let Some(source) = source.no_autosquash {
+            self.no_autosquash = Some(source);
         }
         if let Some(source) = source.no_wip {
             self.no_wip = Some(source);
@@ -109,8 +110,8 @@ impl Config {
         self.imperative_subject.unwrap_or(true)
     }
 
-    pub(crate) fn no_fixup(&self) -> bool {
-        self.no_fixup.unwrap_or(true)
+    pub(crate) fn no_autosquash(&self) -> bool {
+        self.no_autosquash.unwrap_or(true)
     }
 
     pub(crate) fn no_wip(&self) -> bool {

--- a/crates/committed/src/main.rs
+++ b/crates/committed/src/main.rs
@@ -45,10 +45,10 @@ struct Options {
     #[arg(long, overrides_with("no_wip"), hide(true))]
     wip: bool,
 
-    #[arg(long, overrides_with("fixup"))]
-    no_fixup: bool,
-    #[arg(long, overrides_with("no_fixup"), hide(true))]
-    fixup: bool,
+    #[arg(long, overrides_with("autosquash"), alias("no_fixup"))]
+    no_autosquash: bool,
+    #[arg(long, overrides_with("no_autosquash"), alias("fixup"), hide(true))]
+    autosquash: bool,
 
     #[arg(
         long = "format",
@@ -70,7 +70,7 @@ impl Options {
         config::Config {
             merge_commit: self.merge_commit(),
             no_wip: self.wip().map(|b| !b),
-            no_fixup: self.fixup().map(|b| !b),
+            no_autosquash: self.autosquash().map(|b| !b),
             ..Default::default()
         }
     }
@@ -83,8 +83,8 @@ impl Options {
         resolve_bool_arg(self.wip, self.no_wip)
     }
 
-    fn fixup(&self) -> Option<bool> {
-        resolve_bool_arg(self.fixup, self.no_fixup)
+    fn autosquash(&self) -> Option<bool> {
+        resolve_bool_arg(self.autosquash, self.no_autosquash)
     }
 }
 

--- a/crates/committed/src/report.rs
+++ b/crates/committed/src/report.rs
@@ -63,7 +63,8 @@ pub(crate) enum Content<'s> {
     NoPunctuation(NoPunctuation),
     Imperative(Imperative<'s>),
     Wip(Wip),
-    Fixup(Fixup),
+    #[serde(alias = "fixup")]
+    Autosquash(Autosquash),
     InvalidCommitFormat(InvalidCommitFormat),
     DisallowedCommitType(DisallowedCommitType),
     MergeCommitDisallowed(MergeCommitDisallowed),
@@ -128,8 +129,8 @@ pub(crate) struct Wip {}
 #[derive(Clone, Debug, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(derive_more::Display)]
-#[display("Fixup commits must be squashed")]
-pub(crate) struct Fixup {}
+#[display("Autosquash commits must be squashed")]
+pub(crate) struct Autosquash {}
 
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
There are three main changes here:

1. Expanded the autosquash prefixes from just `fixup! ` to now include `squash! ` and `amend! `. This ensures better compliance with the Git docs in [git-rebase](https://git-scm.com/docs/git-rebase).
2. To go with (1), aliased `fixup` with `autosquash`. This was done both in the CLI and in the config. Eventually, it may be worth deprecating `fixup` in favour of `autosquash`; however, I am leaving that as a "future change".
3. When autosquash commits are allowed _and_ an autosquash commit is detected, the remaining checks at done on the remainder of the commit message.

I understand that the change from "fixup" to "autosquash" might be a bit of a big change; however, this should be all backwards compatible. Happy to revise the PR if this is a step too far.

Resolves #392

