### PR TITLE
feat: check all autosquash messages

### DIFF
--- a/crates/committed/src/checks.rs
+++ b/crates/committed/src/checks.rs
@@ -344,12 +344,17 @@ pub(crate) fn check_wip(
     }
 }
 
+const FIXUP_PREFIXES: [&str; 3] = ["fixup! ", "squash! ", "amend! "];
+
 pub(crate) fn check_fixup(
     source: report::Source<'_>,
     message: &str,
     report: report::Report,
 ) -> Result<bool, anyhow::Error> {
-    if message.starts_with(FIXUP_PREFIX) {
+    if FIXUP_PREFIXES
+        .iter()
+        .any(|prefix| message.starts_with(prefix))
+    {
         report(report::Message::error(source, report::Fixup {}));
         Ok(true)
     } else {
@@ -358,14 +363,13 @@ pub(crate) fn check_fixup(
 }
 
 pub(crate) fn strip_fixup(message: &str) -> &str {
-    if let Some(message) = message.strip_prefix(FIXUP_PREFIX) {
-        message
-    } else {
-        message
+    for prefix in FIXUP_PREFIXES.iter() {
+        if let Some(message) = message.strip_prefix(prefix) {
+            return message;
+        }
     }
+    message
 }
-
-const FIXUP_PREFIX: &str = "fixup! ";
 
 pub(crate) fn check_merge_commit(
     source: report::Source<'_>,


### PR DESCRIPTION
Expand the autosquash prefixes from just `fixup!` to now include `squash!` and `amend!`. These are the prefixes supported by default when using [Git's `--autosquash`](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash).

To keep the commits atomic as requested in #394, this  commit _only_ changes the functionality, while leaving the configuration as is (thereby creating an mismatch between the config naming, and resulting behaviour)

EDIT: New commit message will be:

Committed, until now, only supported the `fixup!` prefix. The standard Git implementation of `--autosquash` also supports `squash!` and `amend!`. This commit modifies the logic of the handling of `fixup!` to support the other two prefixes in the same way.

Note that this purely changes the logic. Function names and options remain unchanged to ensure backwards compatibility. It may be worth considering renaming this to `autosquash` given it is motivated primarily by Git's `--autosquash` flag.

Ref: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash