### PR TITLE
feat: strip prefix

### DIFF
--- a/crates/committed/src/checks.rs
+++ b/crates/committed/src/checks.rs
@@ -348,13 +348,15 @@ pub(crate) fn check_fixup(
     message: &str,
     report: report::Report,
 ) -> Result<bool, anyhow::Error> {
-    if message.starts_with("fixup! ") {
+    if message.starts_with(FIXUP_PREFIX) {
         report(report::Message::error(source, report::Fixup {}));
         Ok(true)
     } else {
         Ok(false)
     }
 }
+
+const FIXUP_PREFIX: &str = "fixup! ";
 
 pub(crate) fn check_merge_commit(
     source: report::Source<'_>,

--- a/crates/committed/src/checks.rs
+++ b/crates/committed/src/checks.rs
@@ -3,7 +3,7 @@ use committed::Style;
 
 pub(crate) fn check_message(
     source: report::Source<'_>,
-    message: &str,
+    mut message: &str,
     config: &crate::config::Config,
     report: report::Report,
 ) -> Result<bool, anyhow::Error> {
@@ -19,6 +19,7 @@ pub(crate) fn check_message(
     }
     if config.no_fixup() {
         failed |= check_fixup(source, message, report)?;
+        message = strip_fixup(message);
     }
     // Bail out due to above checks
     if failed {
@@ -353,6 +354,14 @@ pub(crate) fn check_fixup(
         Ok(true)
     } else {
         Ok(false)
+    }
+}
+
+pub(crate) fn strip_fixup(message: &str) -> &str {
+    if let Some(message) = message.strip_prefix(FIXUP_PREFIX) {
+        message
+    } else {
+        message
     }
 }
 


### PR DESCRIPTION
If fixups are allowed, then the remainder of the commit message ought to either be either a previous commit's subject line, or a hash:

> If a commit message starts with "squash! ", "fixup! " or "amend! ", the remainder of the subject line is taken as a commit specifier, which matches a previous commit if it matches the subject line or the hash of that commit.

So we can either:

1. Assume that previous commit's subject line was previously validated and do nothing further; or,
2. Validate the remainder of the commit's subject line as is.

This specific implementation opts for the latter.

Resolves #392