### PR TITLE
feat(config): Add allowed_scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+- Allowed scopes support
+
 ## [1.0.20] - 2023-08-07
 
 ### Compatibility

--- a/crates/committed/src/config.rs
+++ b/crates/committed/src/config.rs
@@ -28,6 +28,7 @@ pub(crate) struct Config {
     pub(crate) line_length: Option<usize>,
     pub(crate) style: Option<Style>,
     pub(crate) allowed_types: Option<Vec<String>>,
+    pub(crate) allowed_scopes: Option<Vec<String>>,
     pub(crate) merge_commit: Option<bool>,
 }
 
@@ -46,6 +47,7 @@ impl Config {
             line_length: Some(empty.line_length()),
             style: Some(empty.style()),
             allowed_types: Some(empty.allowed_types().map(|s| s.to_owned()).collect()),
+            allowed_scopes: Some(empty.allowed_scopes().map(|s| s.to_owned()).collect()),
             merge_commit: Some(empty.merge_commit()),
         }
     }
@@ -83,6 +85,9 @@ impl Config {
         }
         if let Some(source) = source.allowed_types {
             self.allowed_types = Some(source);
+        }
+        if let Some(source) = source.allowed_scopes {
+            self.allowed_scopes = Some(source);
         }
         if let Some(source) = source.merge_commit {
             self.merge_commit = Some(source);
@@ -137,6 +142,16 @@ impl Config {
                 b
             })
             .unwrap_or_else(|| Box::new(DEFAULT_TYPES.iter().copied()))
+    }
+
+    pub(crate) fn allowed_scopes<'s>(&'s self) -> Box<dyn Iterator<Item = &str> + 's> {
+        self.allowed_scopes
+            .as_ref()
+            .map(|v| {
+                let b: Box<dyn Iterator<Item = &str>> = Box::new(v.iter().map(|s| s.as_str()));
+                b
+            })
+            .unwrap_or_else(|| Box::new([].iter().copied()))
     }
 
     pub(crate) fn merge_commit(&self) -> bool {

--- a/crates/committed/src/report.rs
+++ b/crates/committed/src/report.rs
@@ -66,6 +66,7 @@ pub(crate) enum Content<'s> {
     Fixup(Fixup),
     InvalidCommitFormat(InvalidCommitFormat),
     DisallowedCommitType(DisallowedCommitType),
+    DisallowedCommitScope(DisallowedCommitScope),
     MergeCommitDisallowed(MergeCommitDisallowed),
 }
 
@@ -154,6 +155,15 @@ where
 #[derive(derive_more::Display)]
 #[display("Disallowed type `{}` used, please use one of {:?}", used, allowed)]
 pub(crate) struct DisallowedCommitType {
+    pub(crate) used: String,
+    pub(crate) allowed: Vec<String>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(derive_more::Display)]
+#[display("Disallowed scope `{}` used, please use one of {:?}", used, allowed)]
+pub(crate) struct DisallowedCommitScope {
     pub(crate) used: String,
     pub(crate) allowed: Vec<String>,
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -19,7 +19,7 @@ committed master..HEAD
 
 - The range excludes the start commit
 - This will Do The Right Thing even when `master` is ahead of when you
-  branched.  `committed` will look for the merge-base between the range end
+  branched. `committed` will look for the merge-base between the range end
   points.
 
 ### Commit Files and `stdin`
@@ -48,7 +48,7 @@ Configuration is read from the following (in precedence order)
 ### Config Fields
 
 | Field                  | Argument          | Format               | Default                                             | Description                                                                                                           |
-|------------------------|-------------------|----------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| ---------------------- | ----------------- | -------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | ignore_author_re       | \-                | regx                 | (none)                                              | Authors to ignore the commits for. Generally used with bots out of your control.                                      |
 | subject_length         | \-                | number               | 50                                                  | Number of columns the subject can occupy                                                                              |
 | line_length            | \-                | number               | 72                                                  | Number of columns any line with a break can occupy, including subject                                                 |
@@ -60,6 +60,7 @@ Configuration is read from the following (in precedence order)
 | no_wip                 | \-                | bool                 | true                                                | Disallow WIP commits                                                                                                  |
 | style                  | \-                | none, [conventional] | none                                                | Commit style convention                                                                                               |
 | allowed_types          | \-                | list of strings      | fix, feat, chore, docs, style, refactor, perf, test | _(Conventional)_ Accepted commit types                                                                                |
+| allowed_scopes         | \-                | list of strings      | none (all scopes allowed)                           | _(Conventional)_ Accepted commit scopes                                                                               |
 | merge_commit           | --no-merge-commit | \-                   | true                                                | Disallow merge commits. Argument is recommended over config file since there are times when merge-commits are wanted. |
 
 [conventional]: https://www.conventionalcommits.org/


### PR DESCRIPTION
Hi,

This PR adds support for `allowed_scopes`. It functions the same way as `allowed_types`, except that the default list is empty, which means that all scopes are allowed.

I hope the changes follow the expectations of this repo. 
I am unsure about the changes I made to `CHANGELOG.md` and to`reference.md` and the commit message itself.

## Details

This feature can be used by adding `allowed_scopes` to the config file:

```toml
allowed_scopes = ["list", "of", "allowed", "scopes"]
```

When using a scope not in the list, the following error is printed:

```
Disallowed scope `wrong` used, please use one of ["list", "of", "allowed", "scopes"]
```

## Notes

Issue #7 mentions a scope "blacklist" as well. I thought about adding a `disallowed_scopes` config as well, but It seems like added complexity at this point. If you have both allowed and disallowed lists, you probably need to check that only one of them is present in the config at the same time + maybe other things I have not thought of.

If a feature for `disallowed_scopes` is also needed, I might code it up in the future if I have the time. But I feel like `allowed_scopes` can stand on its own.

Resolves #7