### PR TITLE
fix(dockerfile): Adjust cargo install path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG DEBIAN_DIST=bullseye
 FROM rust:${DEBIAN_DIST} as builder
 WORKDIR /usr/src/committed
 COPY . .
-RUN cargo install --path .
+RUN cargo install --path ./crates/committed
 
 FROM debian:${DEBIAN_DIST}-slim
 COPY --from=builder /usr/local/cargo/bin/committed /usr/local/bin/committed


### PR DESCRIPTION
The root `Cargo.toml` file is a virtual manifest, which cargo refuses to `cargo install`. Specifying the path to the `committed` binary crate fixes the issue.

A similar fix was already merged for `typos` in crate-ci/typos#1059.