### PR TITLE
chore: Improve pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,22 +3,22 @@ repos:
     rev: v4.5.0
     hooks:
     - id: check-yaml
-      stages: [commit]
+      stages: [pre-commit]
     - id: check-json
-      stages: [commit]
+      stages: [pre-commit]
     - id: check-toml
-      stages: [commit]
+      stages: [pre-commit]
     - id: check-merge-conflict
-      stages: [commit]
+      stages: [pre-commit]
     - id: check-case-conflict
-      stages: [commit]
+      stages: [pre-commit]
     - id: detect-private-key
-      stages: [commit]
+      stages: [pre-commit]
   - repo: https://github.com/crate-ci/typos
     rev: v1.16.20
     hooks:
     - id: typos
-      stages: [commit]
+      stages: [pre-commit]
   - repo: https://github.com/crate-ci/committed
     rev: v1.0.20
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0


### PR DESCRIPTION
This PR has two logical changes which should hopefully improve the contributor experience. It will ensure that `pre-commit` correctly runs, and is correctly installed for everyone.

The two commits are:

* chore: Expand default hooks installed (d08cd1b) <JP-Ellis>

  When developers run `pre-commit install`, pre-commit by default only installed the `pre-commit` hook. The configuration also makes use of the `commit-msg` hook which would remain unused. The developer is required to run `pre-commit install -t commit-msg` (in addition to the default install), which they would only know from inspecting the pre-commit configuration file.

  By specifying both hooks in `default_install_hook_types`, a simple `pre-commit install` will ensure that _both_ hooks are installed. This should hopefully provide a better developer experience and catch a few lints _before_ they are pushed to a branch and cause CI to fail.

  Signed-off-by: JP-Ellis <josh@jpellis.me>

* chore: Replace invalid git hook stage (2bd88eb) <JP-Ellis>

  While working on my other PRs targetting this repository, I was wondering why CI failed despite having installed pre-commit hooks. I quickly realized that the `stages:` are being overwritten from their default and use the non-existent `commit` stage. See for example the git documentation which list the following commit-related hooks:

  - pre-commit
  - pre-merge-commit
  - prepare-commit-msg
  - commit-msg
  - post-commit

  This should hopefully improve the experience of any possible future contributors and avoid unnecessary back-and-forth due to CI failures.

  Signed-off-by: JP-Ellis <josh@jpellis.me>
