### PR TITLE
feat: Accept revert, ci, and build semantic types by default

### DIFF
--- a/crates/committed/src/config.rs
+++ b/crates/committed/src/config.rs
@@ -1,5 +1,5 @@
 static DEFAULT_TYPES: &[&str] = &[
-    "fix", "feat", "chore", "docs", "style", "refactor", "perf", "test",
+    "fix", "feat", "chore", "docs", "style", "refactor", "perf", "test", "revert", "ci", "build",
 ];
 
 #[derive(

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -60,7 +60,7 @@ Configuration is read from the following (in precedence order)
 | no_fixup               | \-                | bool                 | true                                                | Disallow fixup commits                                                                                                |
 | no_wip                 | \-                | bool                 | true                                                | Disallow WIP commits                                                                                                  |
 | style                  | \-                | none, [conventional] | none                                                | Commit style convention                                                                                               |
-| allowed_types          | \-                | list of strings      | fix, feat, chore, docs, style, refactor, perf, test | _(Conventional)_ Accepted commit types                                                                                |
+| allowed_types          | \-                | list of strings      | fix, feat, chore, docs, style, refactor, perf, test, revert, ci, build | _(Conventional)_ Accepted commit types                                                             |
 | allowed_scopes         | \-                | list of strings      | none (all scopes allowed)                           | _(Conventional)_ Accepted commit scopes                                                                               |
 | merge_commit           | --no-merge-commit | \-                   | true                                                | Disallow merge commits. Argument is recommended over config file since there are times when merge-commits are wanted. |
 


### PR DESCRIPTION
To align with other similar tools and prominent prior art
- https://commitlint.js.org/reference/rules#type-enum
- https://jorisroovers.com/gitlint/latest/rules/contrib_rules/#ct1-contrib-title-conventional-commits
- https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type (where the conventional commits practice likely started from)
- https://github.com/commitizen/conventional-commit-types/blob/master/index.json