### PR TITLE
feat: Strip all fixup! prefixes

### DIFF
--- a/crates/committed/src/checks.rs
+++ b/crates/committed/src/checks.rs
@@ -375,7 +375,7 @@ pub(crate) fn check_fixup(
 pub(crate) fn strip_fixup(message: &str) -> &str {
     for prefix in FIXUP_PREFIXES.iter() {
         if let Some(message) = message.strip_prefix(prefix) {
-            return message;
+            return strip_fixup(message);
         }
     }
     message

--- a/crates/committed/tests/cmd.rs
+++ b/crates/committed/tests/cmd.rs
@@ -77,6 +77,17 @@ fn fixup_stops_checks() {
         .stderr_eq(str![]);
 }
 
+#[test]
+fn fixup_multiple() {
+    run_committed("fixup! squash! fixup! bad times ahead", "no_fixup = false")
+        .code(1)
+        .stdout_eq(str![[r#"
+-: error Subject should be capitalized but found `bad`
+
+"#]])
+        .stderr_eq(str![]);
+}
+
 #[track_caller]
 fn run_committed(message: &str, config: &str) -> snapbox::cmd::OutputAssert {
     let root = snapbox::dir::DirRoot::mutable_temp().unwrap();


### PR DESCRIPTION
Fixup of a fixup is a fixup, it works fine e.g. with autosquash