### PR TITLE
Instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,20 @@ Enforce commit standards, whether for:
 ## Install
 
 [Download](https://github.com/crate-ci/committed/releases) a pre-built binary
-(installable via [gh-install](https://github.com/crate-ci/gh-install)).
+(Installable via [gh-install](https://github.com/crate-ci/gh-install)).
 
-Or use rust to install:
+You can also install using a package manager. We support both Cargo and Homebrew.
+
+### Cargo
+
 ```bash
 cargo install committed
+```
+
+### Homebrew
+
+```bash
+brew install committed
 ```
 
 ### pre-commit


### PR DESCRIPTION
`committed` is now [available](https://github.com/Homebrew/homebrew-core/commit/c141466efd03188dbbab76c4b707cef23bd8db94) to install via [Homebrew](https://brew.sh/).